### PR TITLE
Deprecate EBS autoscale example

### DIFF
--- a/ec2/ebs-autoscale/README.md
+++ b/ec2/ebs-autoscale/README.md
@@ -1,5 +1,12 @@
 # AWS Batch and Amazon EBS Autoscale
 
+> [!WARNING]
+> The EBS autoscale project has been deprecated, and should not be used in any project you have going forward. 
+> We recommend that you leverage the [Amazon FSx for Lustre example](../amazon-fsx-for-lustre/README.md) in lieue of this example. 
+
+> [!IMPORTANT]
+> This example will be removed from this repository on August 1, 2024
+
 This infrastructure as code example shows how to dynamically grow a storage volume for scratch data.
 
 This example leverages [amazon-ebs-autoscale](https://github.com/awslabs/amazon-ebs-autoscale) to mount a logical volume on `/scratch` (default: 200GiB).


### PR DESCRIPTION
*Description of changes:*

Added messages to the EBS Autoscale example README that notified users the underlying project has been deprecated and that the example will be deleted on Aug 1, 2024.
